### PR TITLE
Add commit_message and commit_title to merge_pull_request

### DIFF
--- a/app/controllers/auto_merges_controller.rb
+++ b/app/controllers/auto_merges_controller.rb
@@ -20,7 +20,7 @@ class AutoMergesController < ApplicationController
   end
 
   def create
-    auto_merge = current_user.auto_merges.find_or_initialize_by(auto_merge_params.merge(state: 'pending'))
+    auto_merge = current_user.auto_merges.find_or_initialize_by(auto_merge_params.merge(state: 'pending', last_updated: Time.zone.now))
 
     if auto_merge.save!
       render json: auto_merge
@@ -39,6 +39,6 @@ class AutoMergesController < ApplicationController
   private
 
   def auto_merge_params
-    params.require(:pathData).permit(:owner, :repo, :pr_number)
+    params.permit(:owner, :repo, :pr_number, :commit_message, :commit_title)
   end
 end

--- a/app/models/auto_merge.rb
+++ b/app/models/auto_merge.rb
@@ -22,7 +22,7 @@ class AutoMerge < ApplicationRecord
   end
 
   def merge_pull_request
-    user.client.merge_pull_request(owner_repo, pr_number)
+    user.client.merge_pull_request(owner_repo, pr_number, commit_message, { commit_title: commit_title })
   end
 
   def delay_get_pr_details

--- a/db/migrate/20160906205753_add_commit_message_and_commit_title_to_auto_merges.rb
+++ b/db/migrate/20160906205753_add_commit_message_and_commit_title_to_auto_merges.rb
@@ -1,0 +1,6 @@
+class AddCommitMessageAndCommitTitleToAutoMerges < ActiveRecord::Migration[5.0]
+  def change
+    add_column :auto_merges, :commit_message, :string
+    add_column :auto_merges, :commit_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160906070647) do
+ActiveRecord::Schema.define(version: 20160906205753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,10 +24,12 @@ ActiveRecord::Schema.define(version: 20160906070647) do
     t.string   "ref"
     t.string   "job_id"
     t.datetime "last_updated"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
     t.json     "statuses"
     t.string   "title"
+    t.string   "commit_message"
+    t.string   "commit_title"
     t.index ["owner"], name: "index_auto_merges_on_owner", using: :btree
     t.index ["pr_number"], name: "index_auto_merges_on_pr_number", using: :btree
     t.index ["repo"], name: "index_auto_merges_on_repo", using: :btree


### PR DESCRIPTION
extension: https://github.com/tennisonchan/octomerge/pull/3

Permit params `commit_title` and `commit_message`
Flaten and remove params `pathData`
Add columns `commit_title` and `commit_message` on auto_merges
Merge param `last_updated` as `Time.zone.now` when creating the auto_merges
